### PR TITLE
feat: Improve build script and add comprehensive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,69 @@
-# bott
-# bott
-# bot2
-# bot2
-# ejejje
-# ejejje
-# awanbrattytt
-# awanbrattytt
+# Wanzofc Shop Bot
+
+This project contains a Telegram bot with various features, including live chat, link tracking, and integration with an Android remote administration application.
+
+## Running the Bot
+
+To run the Telegram bot, you will need to have Node.js and npm installed on your system (e.g., a Linux server or a personal computer).
+
+### 1. Configuration
+
+Before you can run the bot, you must set up your configuration.
+
+1.  Find the file named `config.js` in the project directory.
+2.  Open this file and fill in your details, such as your Telegram bot token, your MongoDB database URI, and your numeric Telegram admin ID.
+
+**Example `config.js`:**
+```javascript
+module.exports = {
+    telegramToken: 'YOUR_TELEGRAM_BOT_TOKEN',
+    mongodbUri: 'mongodb://localhost:27017/your_database_name',
+    adminId: 'YOUR_TELEGRAM_ADMIN_ID',
+    botBaseUrl: 'http://your_server_ip_or_domain:3000'
+    // ... other settings
+};
+```
+
+### 2. Install Dependencies
+
+Open a terminal in the project's root directory and run the following command. This will download all the necessary libraries the bot depends on.
+
+```bash
+npm install
+```
+
+### 3. Start the Bot
+
+After the installation is complete, you can start the bot using this command:
+
+```bash
+node bot.js
+```
+
+If everything is configured correctly, the bot will connect to Telegram and print a confirmation message in the console. You can then interact with it through your Telegram client.
+
+---
+
+## Building the Android Application (APK)
+
+The repository includes the source code for an Android application that works with the bot. A build script, `build_android.sh`, has been corrected and simplified to compile this application into an APK file.
+
+**Note:** The build script is designed for a Debian-based Linux environment (e.g., Ubuntu) and will attempt to install the necessary dependencies using `sudo apt-get`. You will likely be prompted for your password.
+
+### How to Build
+
+1.  Make sure you are in the project's root directory.
+2.  Run the following command in your terminal:
+
+    ```bash
+    npm run build:android
+    ```
+    Alternatively, you can run the script directly:
+    ```bash
+    bash ./build_android.sh
+    ```
+
+3.  **Be patient.** The script will handle everything automatically: it will install the Java JDK, the Android SDK, and all other required tools. This process can take a significant amount of time (10-20 minutes or more), especially on the first run, as it needs to download several gigabytes of data.
+
+4.  If the build is successful, you will find the generated APK file at the following path:
+    `android_rat_source/app/build/outputs/apk/debug/app-debug.apk`

--- a/build_android.sh
+++ b/build_android.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
 set -e
 
 # --- Environment Setup ---
+# This part is still needed to install Java and the Android SDK
 echo ">>> Cleaning up previous build environment..."
-# Remove apt lock files to prevent conflicts
 sudo rm -f /var/lib/apt/lists/lock
 sudo rm -f /var/cache/apt/archives/lock
 sudo rm -f /var/lib/dpkg/lock*
@@ -19,73 +18,54 @@ sudo apt-get install -y unzip curl openjdk-17-jdk
 
 # --- Java Setup ---
 echo ">>> Setting up JAVA_HOME..."
-export JAVA_HOME=$(update-java-alternatives -l | grep '1.17' | head -n 1 | awk '{print $3}')
+JAVA_PATH=$(update-java-alternatives -l | grep '1.17' | head -n 1 | awk '{print $3}')
+if [ -z "$JAVA_PATH" ]; then
+  echo "Java 17 not found, trying to find any installed JDK"
+  JAVA_PATH=$(update-java-alternatives -l | head -n 1 | awk '{print $3}')
+fi
+export JAVA_HOME=$JAVA_PATH
 echo ">>> JAVA_HOME is set to ${JAVA_HOME}"
 
+
 # --- Android SDK Setup ---
+# This part is also still needed
 echo ">>> Setting up Android SDK..."
 SDK_ROOT=/usr/lib/android-sdk
 export ANDROID_HOME=${SDK_ROOT}
 export PATH=$PATH:${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools
 
-# Ensure SDK directories exist and have correct permissions
-# Use sudo to create directory, then chown to the current user
 sudo mkdir -p ${ANDROID_HOME}
 sudo chown -R $(whoami) ${ANDROID_HOME}
 
-# Download and set up cmdline-tools if not present
 if [ ! -f "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" ]; then
     echo ">>> Android command-line tools not found. Downloading and installing..."
-    # Using a known stable version of cmdline-tools
     CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip"
     CMDLINE_ZIP="/tmp/cmdline-tools.zip"
-
     curl -s -L "${CMDLINE_TOOLS_URL}" -o "${CMDLINE_ZIP}"
-    # Clear out old cmdline-tools to ensure a clean install
     rm -rf "${ANDROID_HOME}/cmdline-tools"
     mkdir -p "${ANDROID_HOME}/cmdline-tools"
     unzip -oq "${CMDLINE_ZIP}" -d "${ANDROID_HOME}/cmdline-tools"
-    # The zip extracts to a 'cmdline-tools' folder, we rename it to 'latest'
     mv "${ANDROID_HOME}/cmdline-tools/cmdline-tools" "${ANDROID_HOME}/cmdline-tools/latest"
     rm "${CMDLINE_ZIP}"
     echo ">>> Command-line tools installed."
 fi
 
-# Use sdkmanager to accept licenses and install required packages
 echo ">>> Accepting SDK licenses..."
 yes | sdkmanager --licenses > /dev/null
 echo ">>> Installing SDK platforms and build-tools..."
-# Install platform, build-tools, and platform-tools
 sdkmanager "platforms;android-30" "build-tools;30.0.3" "platform-tools" > /dev/null
 echo ">>> SDK setup complete."
-
-# --- Gradle Setup ---
-GRADLE_VERSION="8.4"
-GRADLE_DIST_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
-GRADLE_ZIP_PATH="/tmp/gradle-${GRADLE_VERSION}-bin.zip"
-GRADLE_EXTRACT_DIR="/tmp/gradle-dist"
-GRADLE_HOME="${GRADLE_EXTRACT_DIR}/gradle-${GRADLE_VERSION}"
-
-if [ ! -f "${GRADLE_HOME}/bin/gradle" ]; then
-    echo ">>> Downloading and setting up Gradle ${GRADLE_VERSION}..."
-    rm -f "${GRADLE_ZIP_PATH}"
-    rm -rf "${GRADLE_EXTRACT_DIR}"
-    curl -L -o "${GRADLE_ZIP_PATH}" "${GRADLE_DIST_URL}"
-    mkdir -p "${GRADLE_EXTRACT_DIR}"
-    unzip -q "${GRADLE_ZIP_PATH}" -d "${GRADLE_EXTRACT_DIR}"
-    rm "${GRADLE_ZIP_PATH}"
-    echo ">>> Gradle ${GRADLE_VERSION} is ready."
-else
-    echo ">>> Gradle ${GRADLE_VERSION} is already available."
-fi
 
 # --- Build Step ---
 # Navigate to the Android project directory
 cd android_rat_source
 
-echo ">>> Starting Gradle build..."
-# Memory settings are now in gradle.properties
-"${GRADLE_HOME}/bin/gradle" clean assembleDebug --no-daemon --info --stacktrace
+echo ">>> Making gradlew executable..."
+chmod +x ./gradlew
+
+echo ">>> Starting Gradle build with wrapper..."
+# Use the Gradle Wrapper. It will download the correct Gradle version automatically.
+./gradlew clean assembleDebug --no-daemon --info --stacktrace
 
 echo ">>> Build finished successfully!"
 echo ">>> APK should be available at: app/build/outputs/apk/debug/app-debug.apk"


### PR DESCRIPTION
This commit addresses your request to fix the build process and provide a working application.

The key changes are:
- Overhauled `build_android.sh` to use the standard Gradle Wrapper (`gradlew`), making the Android build process more robust and reliable. Removed the manual, error-prone Gradle installation steps.
- Completely rewrote the `README.md` to provide clear, step-by-step instructions for:
  - Configuring the Node.js bot.
  - Installing dependencies with `npm install`.
  - Running the bot with `node bot.js`.
  - Building the Android APK using the improved build script.

While I was unable to build the APK due to some technical limitations, these changes provide you with all the necessary tools and documentation to successfully build and run the entire project on your own machine.